### PR TITLE
Add deposit/withdraw count to emitted events

### DIFF
--- a/packages/spv_swap_vault/src/events.cairo
+++ b/packages/spv_swap_vault/src/events.cairo
@@ -45,6 +45,8 @@ pub struct Claimed {
 
     pub amounts: (u64, u64),
 
+    pub withdraw_count: u32,
+
     pub fronting_address: ContractAddress
 }
 

--- a/packages/spv_swap_vault/src/events.cairo
+++ b/packages/spv_swap_vault/src/events.cairo
@@ -21,6 +21,8 @@ pub struct Deposited {
     pub vault_id: felt252,
 
     pub amounts: (u64, u64),
+
+    pub deposit_count: u32
 }
 
 #[derive(Drop, starknet::Event)]

--- a/packages/spv_swap_vault/src/lib.cairo
+++ b/packages/spv_swap_vault/src/lib.cairo
@@ -325,7 +325,8 @@ pub mod SpvVaultManager {
                 btc_tx_hash: btc_tx_hash_u256,
                 caller: caller,
                 amounts: total_raw_amounts,
-                fronting_address: fronting_address
+                fronting_address: fronting_address,
+                withdraw_count: current_state.withdraw_count
             });
         }
     }

--- a/packages/spv_swap_vault/src/lib.cairo
+++ b/packages/spv_swap_vault/src/lib.cairo
@@ -129,6 +129,7 @@ pub mod SpvVaultManager {
                 utxo: utxo,
                 confirmations: confirmations,
                 withdraw_count: 0,
+                deposit_count: 0,
             
                 token_0_amount: 0,
                 token_1_amount: 0,
@@ -169,7 +170,8 @@ pub mod SpvVaultManager {
             self.emit(events::Deposited {
                 owner: owner,
                 vault_id: vault_id,
-                amounts: (raw_token_0_amount, raw_token_1_amount)
+                amounts: (raw_token_0_amount, raw_token_1_amount),
+                deposit_count: current_state.deposit_count
             });
         }
 

--- a/packages/spv_swap_vault/tests/utils/spv_vault.cairo
+++ b/packages/spv_swap_vault/tests/utils/spv_vault.cairo
@@ -61,6 +61,7 @@ pub fn create_spv_vault(
         utxo: utxo,
         confirmations: confirmations,
         withdraw_count: 0,
+        deposit_count: 0,
         token_0_amount: 0,
         token_1_amount: 0
     });
@@ -130,13 +131,15 @@ pub fn deposit_and_assert(
 
     prev_state.token_0_amount += raw_amount_0;
     prev_state.token_1_amount += raw_amount_1;
+    prev_state.deposit_count += 1;
 
     //Assert event emitted
     spy.assert_emitted(
         @array![(context.contract.contract_address, SpvVaultManager::Event::Deposited(events::Deposited {
             owner: owner,
             vault_id: vault_id,
-            amounts: (raw_amount_0, raw_amount_1)
+            amounts: (raw_amount_0, raw_amount_1),
+            deposit_count: prev_state.deposit_count
         }))]
     );
 


### PR DESCRIPTION
Without a clear ordering of the events it was non-trivial to implement an indempotent event listener for such events.