### PR TITLE
Fix span hasher

### DIFF
--- a/packages/escrow_manager/src/utils/option_hash.cairo
+++ b/packages/escrow_manager/src/utils/option_hash.cairo
@@ -1,5 +1,9 @@
 use core::hash::{HashStateTrait, HashStateExTrait, Hash};
 
+//NOTE: This is not generally a secure approach for hashing options, the hasher should always
+// prefix the state of the option hence, in case of some -> 1 <value>, in case of none -> 0.
+// This is kept as is for now as to change how hashes are computed currently in atomiq
+//TODO: Update this in next major update
 pub impl OptionHashImpl<HashState, +HashStateTrait<HashState>, +Drop<HashState>, T, +Hash<T, HashState>, +Drop<T>> of Hash<Option<T>, HashState> {
     fn update_state(state: HashState, value: Option<T>) -> HashState {
         if value.is_some() {

--- a/packages/execution_contract/src/utils.cairo
+++ b/packages/execution_contract/src/utils.cairo
@@ -23,12 +23,19 @@ mod tests {
     #[test]
     fn span_hash() {
         let hash = PoseidonTrait::new().update_with(array![0, 1, 2, 3, 4, 5, 6, 7].span()).finalize();
-        assert_eq!(hash, 0x4f5c3b7e3c8019d970747c33fd9318efc139b091115bad66c70a19e0ff430d3);
         assert!(hash != PoseidonTrait::new().update_with(array![0, 1, 2, 3, 4, 5, 6, 6].span()).finalize());
 
         let hash = PoseidonTrait::new().update_with(array![0, 0, 0, 0, 0, 0, 0, 0].span()).finalize();
-        assert_eq!(hash, 0x693df69325f0dd414a3d3af06b5839221d1de6574f95cdde7582b21d83708e5);
         assert!(hash != PoseidonTrait::new().update_with(array![0, 0, 0, 0, 0, 0, 0, 1].span()).finalize());
+    }
+
+    #[test]
+    fn properly_delimetered_spans() {
+        let hash = PoseidonTrait::new()
+            .update_with(array![0, 1, 2, 3].span())
+            .update_with(array![4, 5, 6, 7].span())
+            .finalize();
+        assert!(hash != PoseidonTrait::new().update_with(array![0, 1, 2, 3, 4, 5, 6, 7].span()).finalize());
     }
 
 }

--- a/packages/execution_contract/src/utils.cairo
+++ b/packages/execution_contract/src/utils.cairo
@@ -2,7 +2,9 @@ use core::hash::{HashStateTrait, HashStateExTrait, Hash};
 
 pub impl SpanHashImpl<HashState, +HashStateTrait<HashState>, +Drop<HashState>, T, +Hash<T, HashState>, +Copy<T>> of Hash<Span<T>, HashState> {
     fn update_state(state: HashState, value: Span<T>) -> HashState {
-        let mut result = state;
+        //Always prefix with the span length, such that we have a proper delimeter
+        // whenever we hash multiple spans after each other
+        let mut result = state.update(value.len().into());
         for element in value {
             result = result.update_with(*element);
         };

--- a/packages/execution_contract/tests/execute.cairo
+++ b/packages/execution_contract/tests/execute.cairo
@@ -270,3 +270,39 @@ fn invalid_calls() {
 
     execute_and_assert(context, owner, amount, fee, salt, calls, drain_tokens, false, array![].span(), true);
 }
+
+//Try to maliciously execute no calls by moving all the data to drain tokens
+#[test]
+#[should_panic(expected: 'execute: Invalid calls/tokens')]
+fn malicious_execute_no_calls() {
+    let context = get_context();
+
+    let owner = contract_address_const::<'owner'>();
+    let amount = 1000;
+    let fee = 100;
+    let creator_salt = 0;
+    
+    let event_data = 123481284124123412213123;
+    let entrypoint = 13123121512499412; //Made-up entrypoint, doesn't matter since it won't be executed anyway!
+    let calls: Span<ContractCall> = array![ContractCall {
+        address: context.test_contract,
+        entrypoint: entrypoint,
+        calldata: array![event_data].span()
+    }].span();
+    let drain_tokens: Span<ContractAddress> = array![].span();
+
+    let salt = create_execution(context, owner, amount, fee, 10, creator_salt, calls, drain_tokens);
+
+    //Assume that no delimeters were put inside the execution hash, so we can supply an empty calls array
+    // and move all the data over to the drain tokens
+    execute_and_assert(
+        context, owner, amount, fee, salt,
+        array![].span(), // <--- Empty array here, 
+        array![
+            context.test_contract,
+            entrypoint.try_into().unwrap(),
+            event_data.try_into().unwrap()
+        ].span(), // <--- All the data from the calls moved to the drain tokens here
+        false, array![].span(), true
+    );
+}


### PR DESCRIPTION
This PR fixes possible ambiguity when hashing 2 spans next to each other. Since there was no delimeter used prior, the resulting hash for the same when hashing `[0]` and `[1]` separately and when hashing the arrays together `[0, 1]`. The fix is adding a length prefix in the span hasher, this ensures multiple spans are properly delimetered!