### PR TITLE
Allow anyone to fund escrow

### DIFF
--- a/packages/escrow_manager/src/lib.cairo
+++ b/packages/escrow_manager/src/lib.cairo
@@ -93,29 +93,30 @@ pub mod EscrowManager {
             
             //Check committed
             let escrow_hash = self.escrow_storage._commit(escrow);
-
+            
             //Verify signature
             let caller = execution_info.caller_address;
-            if caller == escrow.offerer {
+            if caller != escrow.claimer {
                 //Here we only require signature in case the reputation tracking flag is set,
                 // otherwise there is no harm done to the claimer even if he were to be spammed
                 // with many escrows
                 if escrow.is_tracking_reputation() {
                     snip6::verify_signature(escrow.claimer, sighash::get_init_sighash(escrow, escrow_hash, timeout, escrow.claimer), signature);
                 }
-            } else if caller == escrow.claimer {
+
+                //Transfer funds - use caller here, as we want to allow anyone to fund the escrow
+                self._pay_in(caller, escrow.token, escrow.amount, escrow.is_pay_in());
+            } else {
                 //In this case we always require signature because we are taking funds from the offerer
                 snip6::verify_signature(escrow.offerer, sighash::get_init_sighash(escrow, escrow_hash, timeout, escrow.offerer), signature);
-            } else {
-                panic(array!['init: caller_address'])
+
+                //Transfer funds from the offerer
+                self._pay_in(escrow.offerer, escrow.token, escrow.amount, escrow.is_pay_in());
             };
 
             //Transfer deposit
             let deposit_amount = escrow.get_total_deposit();
             if deposit_amount!=0 { erc20_utils::transfer_in(escrow.fee_token, caller, deposit_amount) };
-
-            //Transfer funds
-            self._pay_in(escrow.offerer, escrow.token, escrow.amount, escrow.is_pay_in());
 
             //Emit event
             self.emit(events::Initialize {

--- a/packages/escrow_manager/tests/escrow_init.cairo
+++ b/packages/escrow_manager/tests/escrow_init.cairo
@@ -2,6 +2,7 @@ use snforge_std::{
     cheat_caller_address, CheatSpan, generate_random_felt
 };
 use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl};
+use starknet::ContractAddress;
 
 use escrow_manager::structs::escrow::{EscrowDataImpl, EscrowDataImplTrait};
 
@@ -9,6 +10,7 @@ use crate::utils::contract::get_context;
 use crate::utils::result::{assert_result, assert_result_error};
 use crate::utils::escrow::{
     create_escrow_data, init_escrow_and_assert, _init_escrow_and_assert,
+    _create_escrow_data,
     ESCROW_DEPOSIT_SMALL, ESCROW_DEPOSIT_LARGE, ESCROW_INIT_AMOUNT,
     ESCROW_GAS_MINT_AMOUNT, ESCROW_GAS_MINT_NOT_ENOUGH_AMOUNT,
     ESCROW_INIT_MINT_AMOUNT, ESCROW_INIT_MINT_NOT_ENOUGH_AMOUNT
@@ -35,6 +37,33 @@ fn valid_initialize() {
             0
         );
         assert_result(init_escrow_and_assert(context, sender, escrow, signer, 100, 0), escrow);
+    }
+}
+
+//Initialize transaction sent by a third party sender
+#[test]
+fn valid_initialize_3rd_party_sender() {
+    let context = get_context();
+    for i in 0..32_u8 {
+        let random_account: ContractAddress = generate_random_felt().try_into().unwrap();
+        let (_, escrow, signer, _, _) = _create_escrow_data(context,
+            Option::Some(random_account),
+            false,
+            i & 0x1 == 0x1, 
+            i & 0x2 == 0x2,
+            i & 0x4 == 0x4,
+            ESCROW_INIT_MINT_AMOUNT,
+            ESCROW_INIT_AMOUNT,
+            ESCROW_GAS_MINT_AMOUNT,
+            if i & 0x8 == 0x8 { ESCROW_DEPOSIT_SMALL } else { 0 },
+            if i & 0x10 == 0x10 { ESCROW_DEPOSIT_LARGE } else { 0 },
+            true,
+            0
+        );
+        assert_result(
+            init_escrow_and_assert(context, random_account, escrow, signer, 100, 0),
+            escrow
+        );
     }
 }
 
@@ -240,32 +269,6 @@ fn invalid_initialize_wrong_sign_message() {
                 escrow
             );
         }
-    }
-}
-
-//Initialize transaction sent by a third party sender
-#[test]
-fn invalid_initialize_wrong_sender() {
-    let context = get_context();
-    for i in 0..64_u8 {
-        let (_, escrow, signer, _, _) = create_escrow_data(context, 
-            i & 0x1 == 0x1, 
-            i & 0x2 == 0x2,
-            i & 0x4 == 0x4,
-            i & 0x8 == 0x8,
-            ESCROW_INIT_MINT_AMOUNT,
-            ESCROW_INIT_AMOUNT,
-            ESCROW_GAS_MINT_AMOUNT,
-            if i & 0x10 == 0x10 { ESCROW_DEPOSIT_SMALL } else { 0 },
-            if i & 0x20 == 0x20 { ESCROW_DEPOSIT_LARGE } else { 0 },
-            true,
-            0
-        );
-        assert_result_error(
-            init_escrow_and_assert(context, generate_random_felt().try_into().unwrap(), escrow, signer, 100, 0),
-            'init: caller_address',
-            escrow
-        );
     }
 }
 

--- a/packages/escrow_manager/tests/utils/escrow.cairo
+++ b/packages/escrow_manager/tests/utils/escrow.cairo
@@ -34,8 +34,27 @@ pub const ESCROW_DEPOSIT_LARGE: u256 = 150;
 
 pub const INIT_BLOCK_NUMBER: u64 = 8577342;
 
+
 pub fn create_escrow_data(
     context: Context,
+    sender_claimer: bool, pay_in: bool, pay_out: bool, reputation: bool,
+    mint_amount: u256, escrow_amount: u256,
+    gas_mint_amount: u256, security_deposit: u256, claimer_bounty: u256,
+    add_success_action: bool, success_action_fee: u256
+) -> (ContractAddress, structs::escrow::EscrowData, KeyPair<felt252, felt252>, KeyPair<felt252, felt252>, KeyPair<felt252, felt252>) {
+    _create_escrow_data(
+        context,
+        Option::None,
+        sender_claimer, pay_in, pay_out, reputation,
+        mint_amount, escrow_amount,
+        gas_mint_amount, security_deposit, claimer_bounty,
+        add_success_action, success_action_fee
+    )
+}
+
+pub fn _create_escrow_data(
+    context: Context,
+    funder_option: Option<ContractAddress>,
     sender_claimer: bool, pay_in: bool, pay_out: bool, reputation: bool,
     mint_amount: u256, escrow_amount: u256,
     gas_mint_amount: u256, security_deposit: u256, claimer_bounty: u256,
@@ -44,13 +63,14 @@ pub fn create_escrow_data(
     let (offerer, offerer_keypair) = deploy_account();
     let (claimer, claimer_keypair) = deploy_account();
 
-    let sender = if sender_claimer { claimer } else { offerer };
+    let sender = funder_option.unwrap_or(if sender_claimer { claimer } else { offerer });
+    let funder = funder_option.unwrap_or(offerer);
     let signer = if sender_claimer { offerer_keypair } else { claimer_keypair };
 
     if pay_in {
-        erc20::mint(context.token, offerer, mint_amount);
+        erc20::mint(context.token, funder, mint_amount);
     } else {
-        lp_vault::mint_to_lp_vault(context.contract_address, offerer, context.token, mint_amount);
+        lp_vault::mint_to_lp_vault(context.contract_address, funder, context.token, mint_amount);
     }
 
     if claimer_bounty!=0 || security_deposit!=0 {
@@ -94,7 +114,7 @@ pub fn create_escrow_data(
 
     //Increase allowance for token
     if pay_in {
-        cheat_caller_address(context.token.contract_address, offerer, CheatSpan::TargetCalls(1));
+        cheat_caller_address(context.token.contract_address, funder, CheatSpan::TargetCalls(1));
         context.token.approve(context.contract_address, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe);
     }
 
@@ -122,8 +142,11 @@ pub fn _init_escrow_and_assert(
     timeout: u64, current_time: u64,
     sign_random_message: bool, sign_different_timeout: bool
 ) -> Result<(), felt252> {
-    let balance_erc20 = context.token.balance_of(escrow.offerer);
-    let balance_contract = *ILPVaultDispatcher{contract_address: context.contract_address}.get_balance(array![(escrow.offerer, context.token.contract_address)].span()).span()[0];
+    let claimer_inits = sender == escrow.claimer;
+    let funder = if claimer_inits { escrow.offerer } else { sender }; 
+
+    let balance_erc20 = context.token.balance_of(funder);
+    let balance_contract = *ILPVaultDispatcher{contract_address: context.contract_address}.get_balance(array![(funder, context.token.contract_address)].span()).span()[0];
     let balance_erc20_contract = context.token.balance_of(context.contract_address);
 
     let balance_gas_erc20 = context.gas_token.balance_of(sender);
@@ -131,10 +154,10 @@ pub fn _init_escrow_and_assert(
 
     let escrow_hash = escrow.get_struct_hash();
 
-    let signature = if sender==escrow.offerer && !escrow.is_tracking_reputation() {
+    let signature = if !claimer_inits && !escrow.is_tracking_reputation() {
         array![] //Signature not required
     } else {
-        let signer_address = if escrow.offerer == sender { escrow.claimer } else { escrow.offerer };
+        let signer_address = if claimer_inits { escrow.offerer } else { escrow.claimer };
         let sighash = if sign_random_message { 
             generate_random_felt()
         } else {
@@ -178,12 +201,12 @@ pub fn _init_escrow_and_assert(
 
 
     if escrow.is_pay_in() {
-        if (context.token.balance_of(escrow.offerer) != balance_erc20-escrow.amount) ||
+        if (context.token.balance_of(funder) != balance_erc20-escrow.amount) ||
             (context.token.balance_of(context.contract_address) != balance_erc20_contract+escrow.amount) {
             return Result::Err('test: erc20 balance');
         }
     } else {
-        if (ILPVaultDispatcher{contract_address: context.contract_address}.get_balance(array![(escrow.offerer, context.token.contract_address)].span()) != array![balance_contract-escrow.amount]) {
+        if (ILPVaultDispatcher{contract_address: context.contract_address}.get_balance(array![(funder, context.token.contract_address)].span()) != array![balance_contract-escrow.amount]) {
             return Result::Err('test: vault balance');
         }
     }


### PR DESCRIPTION
This PR allows anyone (not just the escrow-specified offerer) to initialize and fund the escrow through the escrow contracts. This allows a separation of "who funds" and "who gets the funds back after refund" in the escrow contract.

The change optimizes for minimal changes to the contract, so there is no additional flag added and the escrow contracts **always** allows anyone to fund the escrow on behalf of the offerer.